### PR TITLE
Bump bootstrap from 4.1.1 to 4.3.1 in /msbuild-example/MsbuildExample

### DIFF
--- a/msbuild-example/MsbuildExample/packages.config
+++ b/msbuild-example/MsbuildExample/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="bootstrap" version="4.1.1" targetFramework="net461" />
+  <package id="bootstrap" version="4.3.1" targetFramework="net461" />
   <package id="jQuery" version="3.0.0" targetFramework="net461" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net461" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net461" />


### PR DESCRIPTION
Bumps bootstrap from 4.1.1 to 4.3.1.

---
updated-dependencies:
- dependency-name: bootstrap
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>